### PR TITLE
Update appinsights location - disallowed by policy

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "location" {
 
 // as of now, UK South is unavailable for Application Insights
 variable "appinsights_location" {
-  default     = "West Europe"
+  default     = "UK South"
   description = "Location for Application Insights"
 }
 


### PR DESCRIPTION
```
Code="RequestDisallowedByPolicy" Message="Resource 'rpx-aat' was disallowed by policy. Reasons: 'Resource doesn't meet location requirements. See https://github.com/hmcts/azure-policy/blob/master/policies/allowed_regions/README.md'. See error details for policy resource IDs." Target="rpx-aat" AdditionalInfo=[{"info":{"evaluationDetails":{"evaluatedExpressions":
```


Changing location to UK South to meet these requirements and let the build run


<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
