### PR TITLE
adoption-aat-mi requires access to rpx-aat KV

### DIFF
--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,1 +1,1 @@
-additional_managed_identities_access = ["et", "sptribs", "civil", "ia", "sscs", "fpl", "prl", "rpa", "dg-docassembly", "dm", "finrem", "div"]
+additional_managed_identities_access = ["et", "sptribs", "civil", "ia", "sscs", "fpl", "prl", "rpa", "dg-docassembly", "dm", "finrem", "div", "adoption"]


### PR DESCRIPTION
### Change description ###
adoption-aat-mi requires access to rpx-aat KV

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
