### PR TITLE
Added cmc-aat-mi to rpx-aat KV access

### DIFF
--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,1 +1,1 @@
-additional_managed_identities_access = ["et", "sptribs", "civil", "ia", "sscs", "fpl", "prl", "rpa", "dg-docassembly", "dm", "finrem", "div", "adoption"]
+additional_managed_identities_access = ["et", "sptribs", "civil", "ia", "sscs", "fpl", "prl", "rpa", "dg-docassembly", "dm", "finrem", "div", "adoption", "cmc"]


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15907


### Change description ###
Adding cmc to aat.tfvars to grant access to rpx-aat KV. Should resolve issue with cmc-citizen-frontend pipeline where PRs are failing in preview/dev env.
https://build.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcmc-citizen-frontend/detail/PR-3638/5/pipeline/

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
